### PR TITLE
feat(package): update `sentence-splitter` to 3.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "prettier": "prettier --write **/*.js"
   },
   "dependencies": {
-    "sentence-splitter": "^3.0.7",
+    "sentence-splitter": "^3.0.8",
     "textlint-rule-helper": "^2.0.0",
     "textlint-util-to-string": "^2.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1246,7 +1246,7 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.4.3:
+es-abstract@^1.4.3, es-abstract@^1.6.1:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.10.0.tgz#1ecb36c197842a00d8ee4c2dfd8646bb97d60864"
   dependencies:
@@ -1475,7 +1475,7 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     mkdirp ">=0.5 0"
     rimraf "2"
 
-function-bind@^1.0.2, function-bind@^1.1.1:
+function-bind@^1.0.2, function-bind@^1.1.0, function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
@@ -2393,6 +2393,15 @@ object.omit@^2.0.0:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
 
+object.values@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.0.4.tgz#e524da09b4f66ff05df457546ec72ac99f13069a"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.6.1"
+    function-bind "^1.1.0"
+    has "^1.0.1"
+
 once@^1.3.0, once@^1.3.1, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -3007,12 +3016,13 @@ sentence-case@^1.1.2:
   dependencies:
     lower-case "^1.1.1"
 
-sentence-splitter@^3.0.7:
-  version "3.0.7"
-  resolved "https://registry.yarnpkg.com/sentence-splitter/-/sentence-splitter-3.0.7.tgz#80a1ab7e554c2e42b89c5911cae37654f2c33e82"
+sentence-splitter@^3.0.8:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/sentence-splitter/-/sentence-splitter-3.0.8.tgz#45fad70c65b097eb63e86d793080d84cc43d677a"
   dependencies:
     "@textlint/ast-node-types" "^3.0.0"
     concat-stream "^1.5.2"
+    object.values "^1.0.4"
     structured-source "^3.0.2"
 
 set-blocking@~2.0.0:


### PR DESCRIPTION
Update `sentence-splitter` to support Node.js v6 or earlier
(azu/sentence-splitter#11).

https://github.com/azu/sentence-splitter/releases/tag/3.0.8