### PR TITLE
feat: add `skipPatterns` and `skipUrlStringLink` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ Add "sentence-length" to your `.textlintrc`.
     - default: 100
     - The total number of characters allowed on each sentences.
     - Sentence.length > 100 and throw Error
-- `exclusionPatterns`: `string[]`
+- `skipPatterns`: `string[]`
     - A strings that match the patterns is uncount of the sentence.
     - Set an array of RegExp-like string.
     - See https://github.com/textlint/regexp-string-matcher
+- `skipUrlStringLink`: `boolean`
+    - Default: `true`
+    - If it is `true`, skip url string link node like `<https:example.com>` or [https://example.com](https://example.com)
+    - url string link is has the text which is same of url.
 
 ```
 {
@@ -47,7 +51,7 @@ Uncount `(...)` from `A sentence(...).`
     "rules": {
         "sentence-length": {
             "max": 100,
-            "exclusionPatterns": [
+            "skipPattern": [
                 "/\\(.*\\)$\\./"
             ]
 

--- a/src/sentence-length.ts
+++ b/src/sentence-length.ts
@@ -3,6 +3,7 @@ import { StringSource } from "textlint-util-to-string";
 import { RuleHelper } from "textlint-rule-helper";
 import { createRegExp } from "@textlint/regexp-string-matcher";
 import { TextlintRuleReporter } from "@textlint/types";
+import { TxtNode, TxtParentNode } from "@textlint/ast-node-types";
 
 function removeRangeFromString(text: string, regExpStrings: string[]) {
     const patterns = regExpStrings.map((pattern) => {
@@ -17,20 +18,50 @@ function removeRangeFromString(text: string, regExpStrings: string[]) {
 
 export type Options = {
     max?: number;
+    /**
+     * The strings that match following patterns is un-count of the sentence
+     * See https://github.com/textlint/regexp-string-matcher
+     */
+    skipPatterns?: string[];
+    /**
+     * If it is true, skip the count of following link node.
+     *
+     * [https://example.com](https://example.com)
+     * <https://example.com>
+     *
+     * UrlStringLink is has the title which is same of href.
+     */
+    skipUrlStringLink?: boolean;
+    /**
+     * @deprecated use skipPatterns
+     */
     exclusionPatterns?: string[];
 };
 const defaultOptions: Required<Options> = {
     max: 100,
-    // The strings that match following patterns is uncount of the sentence
-    // See https://github.com/textlint/regexp-string-matcher
+    skipPatterns: [],
+    skipUrlStringLink: true,
+    /**
+     * @deprecated
+     */
     exclusionPatterns: []
 };
 
 const reporter: TextlintRuleReporter<Options> = (context, options = {}) => {
     const maxLength = options.max ?? defaultOptions.max;
-    const exclusionPatterns = options.exclusionPatterns ?? defaultOptions.exclusionPatterns;
+    const skipPattern = options.skipPatterns ?? options.exclusionPatterns ?? defaultOptions.skipPatterns;
+    const skipUrlStringLink = options.skipUrlStringLink ?? defaultOptions.skipUrlStringLink;
     const helper = new RuleHelper(context);
     const { Syntax, RuleError, report } = context;
+    const isUrlStringLink = (node: TxtNode | TxtParentNode): boolean => {
+        if (node.type !== Syntax.Link) {
+            return false;
+        }
+        const linkNode = node as TxtParentNode;
+        const nodeText = new StringSource(linkNode).toString();
+        return node.url === nodeText;
+    };
+
     // toPlainText
     return {
         [Syntax.Paragraph](node) {
@@ -47,17 +78,25 @@ const reporter: TextlintRuleReporter<Options> = (context, options = {}) => {
             paragraph.children
                 .filter((sentence) => sentence.type === SentenceSyntax.Sentence)
                 .forEach((sentence) => {
+                    const filteredSentence = skipUrlStringLink
+                        ? {
+                              ...sentence,
+                              children: sentence.children.filter((sentenceChildNode: TxtNode | TxtParentNode) => {
+                                  return !isUrlStringLink(sentenceChildNode);
+                              })
+                          }
+                        : sentence;
                     // @ts-expect-error: wrong types
-                    const source = new StringSource(sentence);
+                    const source = new StringSource(filteredSentence);
                     const actualText = source.toString();
-                    const sentenceText = removeRangeFromString(actualText, exclusionPatterns);
+                    const sentenceText = removeRangeFromString(actualText, skipPattern);
                     // larger than > 100
                     const actualTextLength = actualText.length;
                     const sentenceLength = sentenceText.length;
                     if (sentenceLength > maxLength) {
-                        const startLine = sentence.loc.start.line;
+                        const startLine = filteredSentence.loc.start.line;
                         report(
-                            sentence,
+                            filteredSentence,
                             new RuleError(`Line ${startLine} sentence length(${
                                 sentenceLength !== actualTextLength
                                     ? `${sentenceLength}, original:${actualTextLength}`

--- a/test/sentence-length-test.ts
+++ b/test/sentence-length-test.ts
@@ -2,6 +2,7 @@ import TextLintTester from "textlint-tester";
 import rule from "../src/sentence-length";
 // @ts-expect-error: no types
 import htmlPlugin from "textlint-plugin-html";
+
 const tester = new TextLintTester();
 
 tester.run("textlint-rule-sentence-length", rule, {
@@ -42,13 +43,20 @@ tester.run("textlint-rule-sentence-length", rule, {
             text: "1234(56789)",
             options: {
                 max: 5,
-                exclusionPatterns: ["/\\(.*\\)$/"]
+                skipPatterns: ["/\\(.*\\)$/"]
             }
         },
         {
             // html node
             // == 12345
             text: "<s>123</s><b>45</b>",
+            options: {
+                max: 5
+            }
+        },
+        {
+            // url string link
+            text: "[http://example.com](http://example.com)",
             options: {
                 max: 5
             }
@@ -202,7 +210,7 @@ Over 2 characters.`,
             text: "123456789(56789)",
             options: {
                 max: 5,
-                exclusionPatterns: ["/\\(.*\\)$/"]
+                skipPatterns: ["/\\(.*\\)$/"]
             },
             errors: [
                 {
@@ -211,6 +219,20 @@ Over 2 characters.`,
                         "Over 4 characters."
                 }
             ]
+        },
+        {
+            // url string link
+            text: "TEST [http://example.com](http://example.com)",
+            errors: [
+                {
+                    message: `Line 1 sentence length(23) exceeds the maximum sentence length of 5.
+Over 18 characters.`
+                }
+            ],
+            options: {
+                max: 5,
+                skipUrlStringLink: false
+            }
         }
     ]
 });
@@ -238,6 +260,10 @@ tester.run(
         valid: [
             {
                 text: "<p>this is a test.</p>",
+                ext: ".html"
+            },
+            {
+                text: "<p>TEST is <a href='https://example.com'>https://example.com</a></p>",
                 ext: ".html"
             }
         ],

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "**/*",
+    "../src/**/*"
+  ]
+}


### PR DESCRIPTION
BRREAKING CHANGE: skip to count of  url string link by default

- Add`skipPatterns` instead of `exclusionPatterns`
	- Now, deprecate `exclusionPatterns`
- Add `skipUrlStringLink` and Enable it by default

fix #15 