### PR TITLE
feat: count string by codepoint

### DIFF
--- a/src/sentence-length.ts
+++ b/src/sentence-length.ts
@@ -70,7 +70,7 @@ const strLenByCodeUnits = (s: string): number => s.length;
  * Complexity: O(n)
  * @param s string
  */
-const strLenByCodePoint = (s: string): number => {
+const strLenByCodePoints = (s: string): number => {
     let i = 0;
     for (const _ of s) {
         ++i;
@@ -81,7 +81,7 @@ const reporter: TextlintRuleReporter<Options> = (context, options = {}) => {
     const maxLength = options.max ?? defaultOptions.max;
     const skipPatterns = options.skipPatterns ?? options.exclusionPatterns ?? defaultOptions.skipPatterns;
     const skipUrlStringLink = options.skipUrlStringLink ?? defaultOptions.skipUrlStringLink;
-    const strLen = options.countBy == null || options.countBy === "codeunits" ? strLenByCodeUnits : strLenByCodePoint;
+    const strLen = options.countBy == null || options.countBy === "codeunits" ? strLenByCodeUnits : strLenByCodePoints;
     const helper = new RuleHelper(context);
     const { Syntax, RuleError, report } = context;
     const isUrlStringLink = (node: TxtSentenceNodeChildren): boolean => {

--- a/src/sentence-length.ts
+++ b/src/sentence-length.ts
@@ -39,10 +39,10 @@ export type Options = {
     exclusionPatterns?: string[];
     /**
      * Determine how to count string length.
-     * By default or set to "code units", count string by UTF-16 code unit(= using `String.prototype.length`).
+     * By default or set to "codeunits", count string by UTF-16 code unit(= using `String.prototype.length`).
      * If set to "codepoints", count string by codepoint.
      */
-    countBy?: "code units" | "codepoints";
+    countBy?: "codeunits" | "codepoints";
 };
 const defaultOptions: Required<Options> = {
     max: 100,
@@ -52,7 +52,7 @@ const defaultOptions: Required<Options> = {
      * @deprecated
      */
     exclusionPatterns: [],
-    countBy: "code units"
+    countBy: "codeunits"
 };
 
 const isSentenceNode = (node: TxtParentNodeWithSentenceNodeContent): node is TxtSentenceNode => {

--- a/src/sentence-length.ts
+++ b/src/sentence-length.ts
@@ -58,6 +58,12 @@ const defaultOptions: Required<Options> = {
 const isSentenceNode = (node: TxtParentNodeWithSentenceNodeContent): node is TxtSentenceNode => {
     return node.type === SentenceSplitterSyntax.Sentence;
 };
+
+/**
+ * A count of the number of code units currently in the string.
+ * @param s string
+ */
+const strLenByCodeUnits = (s: string): number => s.length;
 /**
  * A count of the number of codepoint currently in the string.
  *
@@ -75,8 +81,7 @@ const reporter: TextlintRuleReporter<Options> = (context, options = {}) => {
     const maxLength = options.max ?? defaultOptions.max;
     const skipPatterns = options.skipPatterns ?? options.exclusionPatterns ?? defaultOptions.skipPatterns;
     const skipUrlStringLink = options.skipUrlStringLink ?? defaultOptions.skipUrlStringLink;
-    const strLen =
-        options.countBy == null || options.countBy === "code units" ? (s: string) => s.length : strLenByCodePoint;
+    const strLen = options.countBy == null || options.countBy === "codeunits" ? strLenByCodeUnits : strLenByCodePoint;
     const helper = new RuleHelper(context);
     const { Syntax, RuleError, report } = context;
     const isUrlStringLink = (node: TxtSentenceNodeChildren): boolean => {

--- a/test/sentence-length-test.ts
+++ b/test/sentence-length-test.ts
@@ -118,6 +118,13 @@ Shopify Functionで利用されるが、非同期処理の制限や5ms未満で�
                 max: 10,
                 skipPatterns: ['/".*"/']
             }
+        },
+        {
+            text: "𦥑井と臼井",
+            options: {
+                max: 5,
+                countBy: "codepoints"
+            }
         }
     ],
     invalid: [
@@ -248,6 +255,18 @@ Over 18 characters.`
             options: {
                 max: 5,
                 skipUrlStringLink: false
+            }
+        },
+        {
+            text: "𦥑井と臼井",
+            errors: [
+                {
+                    message: `Line 1 sentence length(6) exceeds the maximum sentence length of 5.
+Over 1 characters.`
+                }
+            ],
+            options: {
+                max: 5
             }
         }
     ]


### PR DESCRIPTION
# Abstruct

Unicode says that there are 4 ways to count string length. https://unicode.org/faq/char_combmark.html#7

This commit supports counting by Code points.

# Motivation

When we write text something like Japanese, surrogate pair will be used as usual. In such context, restricting string length is painful without considering surrogate pair.