### PR TITLE
fix: treat HTML Comment nodes as zero-length strings

### DIFF
--- a/src/sentence-length.ts
+++ b/src/sentence-length.ts
@@ -119,7 +119,16 @@ const reporter: TextlintRuleReporter<Options> = (context, options = {}) => {
                           })
                       }
                     : sentence;
-                const source = new StringSource(filteredSentence);
+                const source = new StringSource(filteredSentence, {
+                    // https://github.com/textlint-rule/textlint-rule-sentence-length/issues/45
+                    // Treat Comment nodes as zero-length strings
+                    replacer({ node, emptyValue }) {
+                        if (node.type === "Comment") {
+                            return emptyValue();
+                        }
+                        return;
+                    }
+                });
                 const actualText = source.toString();
                 const sentenceText = removeRangeFromString(actualText, skipPatterns);
                 // larger than > 100

--- a/test/sentence-length-html-test.ts
+++ b/test/sentence-length-html-test.ts
@@ -33,6 +33,23 @@ const tester = new TextLintTester();
                 {
                     text: "<p>TEST is <a href='https://example.com'>https://example.com</a></p>",
                     ext: ".html"
+                },
+                // https://github.com/textlint-rule/textlint-rule-sentence-length/issues/45
+                // Comment inside <p> should be ignored (length 0)
+                {
+                    text: "<p><!-- this is a very long comment that should be ignored --></p>",
+                    ext: ".html"
+                },
+                {
+                    text: `<p>
+<!--
+comment-->
+</p>`,
+                    ext: ".html"
+                },
+                {
+                    text: "<p>short text<!-- long long long long long long comment --></p>",
+                    ext: ".html"
                 }
             ],
             invalid: [


### PR DESCRIPTION
## Summary

This PR fixes an issue where HTML comment nodes inside `<p>` tags were incorrectly counted toward sentence length. When using textlint-plugin-html, comments like `<!-- comment -->` inside paragraph tags generate `Comment` nodes in the AST. These nodes were being treated as text content by `StringSource`, causing false positives when the comment text was long.

The fix uses `StringSource`'s `replacer` option to detect `Comment` nodes and replace them with zero-length strings via `emptyValue()`.

Fixes #45

## Changes

- Modified `src/sentence-length.ts` to pass a `replacer` function to `StringSource` that treats `Comment` nodes as zero-length strings
- Added test cases in `test/sentence-length-html-test.ts` covering:
  - Empty paragraph with long comment
  - Multi-line comment inside paragraph
  - Short text followed by long comment

## Test Plan

N/A - Automated tests cover the fix with multiple scenarios for HTML comment handling.

---

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
